### PR TITLE
set CURL_CA

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -29,8 +29,8 @@
 :: Enhance Path
 @set git_install_root=%pentestbox_ROOT%\base\PortableGit
 @set PATH=%pentestbox_ROOT%\bin;%git_install_root%\bin;%git_install_root%\mingw32\bin;%git_install_root%\usr\bin;%git_install_root%\cmd;%git_install_root%\share\vim\vim74;%pentestbox_ROOT%\base\curl\bin;%pentestbox_ROOT%\base\ruby\bin;%pentestbox_ROOT%\base\ruby_devkit\bin;%pentestbox_ROOT%\base\ruby_devkit\mingw\bin;%pentestbox_ROOT%\base\strawberry-perl\perl\bin;%pentestbox_ROOT%\base\strawberry-perl\c\bin;%pentestbox_ROOT%\base\strawberry-perl\;%pentestbox_ROOT%\bin\nmap;%pentestbox_ROOT%\base\jdk1.8.0_74\bin;%pentestbox_ROOT%\base\jdk1.8.0_74\jre\bin;%pentestbox_ROOT%\base\jdk1.8.0_74\jre\lib;%pentestbox_ROOT%\bin\aircrack-ng-1.2-rc4-win\bin\32bit;%pentestbox_ROOT%\bin\password_attacks\rainbowcrack;%pentestbox_ROOT%\bin\androidsecurity\dex2jar;%pentestbox_ROOT%\bin\androidsecurity\sdk\platform-tools;%pentestbox_ROOT%\bin\7za;%pentestbox_ROOT%\bin\wget;%SystemRoot%\system32;%pentestbox_ROOT%\base\python;%pentestbox_ROOT%\base\python3
-@set CURL_CA_BUNDLE=C:\PentestBox\base\curl\bin\ca-bundle.crt
-@set SSL_CERT_FILE=C:\PentestBox\base\curl\bin\cacert.pem
+@set CURL_CA_BUNDLE=%pentestbox_ROOT%\base\curl\bin\ca-bundle.crt
+@set SSL_CERT_FILE=%pentestbox_ROOT%\base\curl\bin\cacert.pem
 :: Add aliases
 @doskey /macrofile="%pentestbox_ROOT%\config\aliases"
 :: Custom aliases


### PR DESCRIPTION
use %pentestbox_ROOT% instead of "C:\PentestBox" to prevent curl crash under some conditions